### PR TITLE
Add rec_names to avoid key error

### DIFF
--- a/travel_accommodation/travel_accommodation.py
+++ b/travel_accommodation/travel_accommodation.py
@@ -31,6 +31,7 @@ class travel_accommodation(orm.Model):
     """Accommodation of travel"""
     _description = _(__doc__)
     _name = 'travel.accommodation'
+    _rec_name = 'location'
 
     @staticmethod
     def str_to_date_difference(lhs, rhs):

--- a/travel_journey/travel_journey.py
+++ b/travel_journey/travel_journey.py
@@ -38,6 +38,7 @@ class travel_journey(orm.Model):
     _name = 'travel.journey'
     _description = _(__doc__)
     _journey_type_classes = {}
+    _rec_name = 'destination'
 
     @staticmethod
     def _check_dep_arr_dates(departure, arrival):

--- a/travel_rental_car/travel_rental_car.py
+++ b/travel_rental_car/travel_rental_car.py
@@ -28,6 +28,7 @@ class travel_car_rental(orm.Model):
     """Car Rentals for travel"""
     _name = 'travel.rental.car'
     _description = _(__doc__)
+    _rec_name = 'pickup_loc'
 
     @staticmethod
     def _check_dep_arr_dates(start, end):

--- a/travel_rental_service/travel_rental_service.py
+++ b/travel_rental_service/travel_rental_service.py
@@ -28,6 +28,7 @@ class travel_rental_service(orm.Model):
     """Service rentals for travel"""
     _name = 'travel.rental.service'
     _description = _(__doc__)
+    _rec_name = 'services'
 
     @staticmethod
     def _check_dep_arr_dates(start, end):


### PR DESCRIPTION
Sometimes Odoo will try to find the name of an object
if the name column doesn't exist and there is no _rec_name it will result in: KeyError: "Field 'name' does not exist in object 'browse_record(travel.rental.service, 1)'"
