### PR TITLE
Fix cases where Category name is translated and domain breaks

### DIFF
--- a/travel_journey/travel_journey.py
+++ b/travel_journey/travel_journey.py
@@ -364,10 +364,21 @@ class travel_journey(orm.Model):
             type="date",
             help="Best estimate of end date calculated from filled fields.",
         ),
+        'product_uom_categ_kgm_ref': fields.many2one(
+            'product.uom.categ',
+            'Product Weight Category',
+            readonly=1,
+            required=1,
+        ),
     }
 
     _defaults = {
-        'class_id': _default_class
+        'class_id': _default_class,
+        'product_uom_categ_kgm_ref': (
+            lambda self, cr, uid, *a, **kw:
+            self.pool['ir.model.data'].get_object_reference(
+                cr, uid, 'product', 'product_uom_categ_kgm')[1]
+        ),
     }
 
     _constraints = [

--- a/travel_journey/travel_journey_view.xml
+++ b/travel_journey/travel_journey_view.xml
@@ -55,7 +55,8 @@
                   <field name="baggage_weight_uom"
                          nolabel='1'
                          class="oe_inline"
-                         domain="[('category_id.name', '=', 'Weight')]"/>
+                         domain="[('category_id', '=', product_uom_categ_kgm_ref)]"/>
+                  <field name="product_uom_categ_kgm_ref" invisible="1"/>
                 </div>
               </group>
             </group>


### PR DESCRIPTION
In non-english interfaces the `domain="[('category_id.name', '=', 'Weight')]"` returns nothing since `category_id.name == 'Poids'`

There does not seem to be any way to refer to model datas within `arch` of a view, so `product_uom_categ_kgm_ref` was created to only point at the ID of `product.product_uom_categ_kgm`
