### PR TITLE
[UPD] Remove create and create_edit options

### DIFF
--- a/travel/travel_passenger_view.xml
+++ b/travel/travel_passenger_view.xml
@@ -8,8 +8,11 @@
       <field name="arch" type="xml">
         <form string="Travel Passengers" version="7.0">
           <group name="General" col="4">
-            <field name="partner_id" domain="[('is_company', '=', False)]" on_change="on_change_partner_id(partner_id)"/>
-            <field name="travel_id" invisible="1"/>
+            <field name="partner_id"
+                   domain="[('is_company', '=', False)]"
+                   on_change="on_change_partner_id(partner_id)"
+                   options="{'create': false, 'create_edit': false}"/>
+            <field name="travel_id" invisible="1" />
           </group>
           <notebook name="Info"/>
           <div class="oe_chatter">

--- a/travel/travel_view.xml
+++ b/travel/travel_view.xml
@@ -57,7 +57,8 @@
                 <field name="passenger_ids" nolabel="1">
                   <tree name="TravelPassengerTree" version="7.0" editable="bottom">
                     <field name="partner_id" domain="[('is_company', '=', False)]"
-                           on_change="on_change_partner_id(partner_id)"/>
+                           on_change="on_change_partner_id(partner_id)"
+                           options="{'create': false, 'create_edit': false}" />
                     <button name="action_passenger_form_view"
                             type="object"
                             icon="gtk-open"/>

--- a/travel_accommodation/travel_accommodation_view.xml
+++ b/travel_accommodation/travel_accommodation_view.xml
@@ -11,7 +11,8 @@
             <group col="4">
               <group string="Location" col="2" colspan="2">
                 <field name="location" domain="[('is_accommodation', '=', True)]"
-                       context="{'default_is_accommodation': True, 'default_is_company': True}"/>
+                       context="{'default_is_accommodation': True, 'default_is_company': True}"
+                       options="{'create': false, 'create_edit': false}"/>
                 <field name="close_to"/>
                 <group col="3" colspan="2">
                   <label for="budget"/>

--- a/travel_hr/travel_view.xml
+++ b/travel_hr/travel_view.xml
@@ -22,7 +22,9 @@
       <field name="arch" type="xml">
 
         <field name="date_stop" position="after">
-          <field name="department_id" required="True"/>
+          <field name="department_id"
+                 required="True"
+                 options="{'create': false, 'create_edit': false}"/>
         </field>
 
         <field name="partner_id" position="after">

--- a/travel_journey/travel_journey_view.xml
+++ b/travel_journey/travel_journey_view.xml
@@ -18,16 +18,16 @@
               </group>
               <group string="Cities" col="2" colspan="2">
                 <field name="origin"
-                       options='{"create_name_field": "city"}'
+                       options='{"create_name_field": "city", "create": false, "create_edit": false}'
                        on_change="on_change_return('return_destination', origin)"/>
                 <field name="destination"
-                       options='{"create_name_field": "city"}'
+                       options='{"create_name_field": "city", "create": false, "create_edit": false}'
                        on_change="on_change_return('return_origin', destination)"/>
                 <field name="return_origin"
-                       options='{"create_name_field": "city"}'
+                       options='{"create_name_field": "city", "create": false, "create_edit": false}'
                        attrs="{'invisible': [('is_return', '=', False)]}"/>
                 <field name="return_destination"
-                       options='{"create_name_field": "city"}'
+                       options='{"create_name_field": "city", "create": false, "create_edit": false}'
                        attrs="{'invisible': [('is_return', '=', False)]}"/>
               </group>
               <group string="Times" col="3" colspan="2">

--- a/travel_rental_service/travel_rental_service_view.xml
+++ b/travel_rental_service/travel_rental_service_view.xml
@@ -11,9 +11,10 @@
             <group col="4">
               <group string="Location" col="2" colspan="2">
                 <field name="location" domain="[('is_rental_service', '=', True)]"
-                       context="{'default_is_rental_service': True, 'default_is_company': True}"/>
+                       context="{'default_is_rental_service': True, 'default_is_company': True}"
+                       options="{'create': false, 'create_edit': false}"/>
                 <field name="city_id"
-                       options='{"create_name_field": "city"}'/>
+                       options='{"create_name_field": "city", "create": false, "create_edit": false}'/>
               </group>
               <group string="Times" col="2" colspan="2">
                 <field name="start"


### PR DESCRIPTION
[UPD] Remove create and create_edit options in travel for these fields:
- department_id
- partner_id
- origin
- destination
- return_origin
- return_destination
- location
- city_id
