### PR TITLE
UPD] Remove create and create_edit options for these fields:

### DIFF
--- a/travel_accommodation/travel_accommodation_view.xml
+++ b/travel_accommodation/travel_accommodation_view.xml
@@ -20,7 +20,8 @@
                   <div style="width:25%%">
                     <field name="budget_currency"
                            nolabel='1'
-                           class="oe_inline"/>
+                           class="oe_inline"
+                           options="{'create': false, 'create_edit': false}"/>
                   </div>
                 </group>
               </group>

--- a/travel_journey/travel_journey_view.xml
+++ b/travel_journey/travel_journey_view.xml
@@ -46,7 +46,9 @@
               </group>
 
               <separator string="Class and Baggage" colspan="4"/>
-              <field name="class_id" colspan="4"/>
+              <field name="class_id"
+                     colspan="4"
+                     options="{'create': false, 'create_edit': false}"/>
               <field name="baggage_qty"/>
               <group col="3" colspan="2">
                 <label for="baggage_weight"/>

--- a/travel_passport/travel_passenger_view.xml
+++ b/travel_passport/travel_passenger_view.xml
@@ -9,7 +9,8 @@
 
         <field name="partner_id" position="after">
           <field name="passport_id" domain="[('partner_id', '=', partner_id)]"
-                 context="{'default_partner_id': partner_id}"/>
+                 context="{'default_partner_id': partner_id}"
+                 options="{'create': false, 'create_edit': false}"/>
         </field>
 
       </field>

--- a/travel_rental_car/travel_rental_car_view.xml
+++ b/travel_rental_car/travel_rental_car_view.xml
@@ -12,7 +12,8 @@
               <group string="Location" col="2" colspan="2">
                 <field name="pickup_loc"/>
                 <field name="dropoff_loc"/>
-                <field name="type"/>
+                <field name="type"
+                       options="{'create': false, 'create_edit': false}"/>
               </group>
               <group string="Times" col="2" colspan="2">
                 <field name="start"


### PR DESCRIPTION
Remove create and create_edit options for these fields:
- budget_currency
- class_id
- passport_id
- type
